### PR TITLE
Add sourcing pipeline tools and curation tasking brief

### DIFF
--- a/TASKING.md
+++ b/TASKING.md
@@ -1,0 +1,80 @@
+# Curation tasking brief
+
+This is the working brief for curating visual assets in this repo. It is written so you can pick it up without any other context. If something here contradicts `ASSET-LICENSING.md`, that file wins.
+
+## What this repo is for
+
+The EO-GOS portal shows a page for every Earth-observation mission (~1,200 and growing). This repo supplies the visuals: a stylised SVG of each satellite (our own artwork), PNG renders of those SVGs, and — where we can get one legally — a real photo or render of the spacecraft. `index.json` maps every folder to its CEOS database mission ID and records the licence of every photo. A second asset class, agency/provider logos, is being added under `agencies/` (issue #101).
+
+## The golden rules
+
+1. **Attribution is not a licence.** Saying where an image came from does not give us permission to host it. An image is usable only if its *owner* has granted an open licence (public domain, CC0, CC BY, CC BY-SA, OGL) or their published media terms permit reuse.
+2. **Never source images from Google Images or general web search.** Only from sources that state the licence machine-readably or explicitly: Wikimedia Commons, NASA/NOAA/USGS (US-gov = public domain), agency media pages with stated terms.
+3. **Every photo gets its paperwork before it gets committed:** `imageLicense`, `imageCredit`, `imageSourceURL` in `index.json`, plus a row in `ATTRIBUTIONS.csv`. No exceptions.
+4. **Commercial-operator renders (Tier D) are never taken without explicit permission.** The operators (Planet, ICEYE, Umbra, …) are people we work with; a licensing mistake costs trust, not just a takedown. When in doubt: leave the SVG as the visual (`imageStatus: svg-fallback`) or ask George to email the operator.
+5. **SVGs must be original depictions, not traces.** Drawing the satellite in our house style (using photos only as reference for what it looks like) is our own copyright. A 1:1 trace of one specific render copies that image's composition and is a derivative — don't do it, and flag any existing SVG that looks like one.
+6. **Logos are never redrawn** — official files only (see Task C).
+7. **All work on branches, PR per batch, never commit to `main`.** Keep commit messages plain (no generated-by/co-author trailers).
+
+## Task A — satellite photos (the main job)
+
+Goal: every mission folder gets a properly licensed photo/render of the spacecraft, recorded in `index.json` with `imageStatus: licensed`. Where none exists, `imageStatus: svg-fallback` — the SVG is the visual, and that's fine.
+
+The workflow (from the repo root):
+
+```bash
+# 1. Gather candidates for every entry still pending (or name specific folders)
+python3 tools/commons_gather.py
+
+# 2. Build the review gallery and open it in a browser
+python3 tools/make_gallery.py
+open tools/out/gallery.html
+```
+
+3. **Pick.** This is the judgement step a script can't do: most search hits are the satellite's *data* (pretty pictures of Earth), not the satellite. Pick the best image *of the spacecraft* — renders and pre-launch cleanroom photos both count. Leave "none of these" selected if nothing shows the spacecraft. Click **Export picks** (downloads `picks.json`).
+
+```bash
+# 4. Apply: downloads each pick and writes all the paperwork
+python3 tools/apply_picks.py ~/Downloads/picks.json
+
+# 5. Review what changed, then branch/commit/PR
+git diff
+git checkout -b feat/photos-batch-01
+git add -A && git commit -m "Photos batch 1: <folders>"
+git push -u origin feat/photos-batch-01   # then open a PR
+```
+
+In the PR description, list each mission and its licence. The reviewer checks: is it actually the right satellite, is the licence real (click through to the source page), is the credit sensible.
+
+Batch size: ~10 missions per PR is comfortable to review.
+
+For the ~14 missions Commons can't cover, `image-sourcing-manual-worklist.csv` lists each owner's image library and the licence you're looking for — same paperwork, found by hand. Tier D rows: rule 4 applies.
+
+## Task B — the 12 blank mission IDs (issue #99)
+
+Twelve `index.json` entries have an empty `missionID` because the mapping needs a human call (e.g. the `sentinel-1` folder vs per-satellite A/B/C DB rows; the `ace` folder, whose image is probably the 1997 Advanced Composition Explorer, not missionID 648). Issue #99 has the full list and notes. Resolve each with George — the answer is sometimes "this folder maps to no mission and should be moved to `other-spacecraft/`".
+
+## Task C — agency/provider logos (issue #101)
+
+New asset class under `agencies/<acronym-lowercase>/`, same schema and paperwork as satellites. Differences:
+
+- Logos are **trademarks**: we use them only to identify the agency next to its own missions. The licence bar is different — record `imageStatus: trademark-editorial-use` plus the brand-terms URL when a logo isn't openly licensed but its brand page permits editorial use.
+- **Official files only, never redrawn.** SVG preferred.
+- Sourcing ladder: (1) Wikimedia Commons — US-gov agency logos are public domain, simple text logos are often `PD-textlogo`; note that logos on *English Wikipedia* (rather than Commons) are usually fair-use and NOT usable. (2) The agency/company's own brand or press page. (3) No logo → the portal shows a text chip, which is fine.
+- Priority: the ~35 CEOS member agencies first (ceos.org's member page is the reference for the *current* logo), then commercial providers (ICEYE, Umbra, iQPS, Planet, Capella, SatVu, Airbus…).
+- `tools/commons_gather.py --terms "ESA logo" --key esa-logo` reuses the *gather and gallery* steps for logo searches. `apply_picks.py` only handles satellite folders — for logos, download the picked file and do the paperwork (folder, index entry, `ATTRIBUTIONS.csv` row) by hand until a logo-aware apply tool exists.
+
+## Adding a brand-new satellite folder
+
+1. Create `satellites/<name>/` — lowercase, matching the portal's naming (ask if unsure).
+2. Add `<name>.svg` (colour) and `<name>-icon.svg` (mono) — your original artwork.
+3. `cd tools && npm install && node render_pngs.mjs` regenerates the PNGs.
+4. Add the `index.json` entry (copy an existing one; missionID from George/the API).
+5. `ATTRIBUTIONS.csv` rows for the new files (repo maintainers, CC BY 4.0).
+
+## Who decides what
+
+- Image is right/wrong, licence reads OK → you decide, PR review catches mistakes.
+- Tier D / permission emails / anything legal-ish → George.
+- Mission-ID ambiguity → George (Task B).
+- Tooling broken or a source that should be automated → flag it in an issue; Claude Code sessions maintain `tools/`.

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+out/

--- a/tools/apply_picks.py
+++ b/tools/apply_picks.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Apply gallery picks: download each chosen image and record its licence.
+
+    python3 tools/apply_picks.py ~/Downloads/picks.json
+
+For every pick this script:
+  1. downloads the full-resolution file to satellites/<folder>/<folder>-photo.<ext>
+  2. sets the entry's PhotoPath, imageSourceURL, imageRightsHolder,
+     imageLicense, imageCredit in index.json and imageStatus to "licensed"
+  3. adds/updates the file's row in ATTRIBUTIONS.csv
+
+Review the git diff, then commit on a branch and open a PR.
+"""
+
+import csv
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+UA = "satellite-visuals-curation/1.0 (https://github.com/gamedaygeorge/satellite-visuals)"
+
+picks = json.load(open(sys.argv[1]))
+index = json.load(open(REPO / "index.json"))
+by_folder = {e["SVGColourPath"].split("/")[1]: e for e in index}
+
+rows = list(csv.reader(open(REPO / "ATTRIBUTIONS.csv")))
+header, body = rows[0], rows[1:]
+by_path = {r[0]: r for r in body}
+
+for folder, pick in picks.items():
+    entry = by_folder.get(folder)
+    if entry is None:
+        print(f"SKIP {folder}: no index.json entry")
+        continue
+
+    ext = pick["url"].rsplit(".", 1)[-1].lower()
+    if ext not in ("jpg", "jpeg", "png", "gif", "webp", "tif", "tiff"):
+        ext = "jpg"
+    rel = f"satellites/{folder}/{folder}-photo.{ext}"
+    req = urllib.request.Request(pick["url"], headers={"User-Agent": UA})
+    (REPO / rel).write_bytes(urllib.request.urlopen(req, timeout=60).read())
+
+    rights = pick.get("artist") or pick.get("credit") or ""
+    entry["PhotoPath"] = rel
+    entry["imageSourceURL"] = pick.get("page") or pick["url"]
+    entry["imageRightsHolder"] = rights or entry.get("imageRightsHolder", "")
+    entry["imageLicense"] = pick["licence"]
+    entry["imageCredit"] = pick.get("credit") or rights
+    entry["imageStatus"] = "licensed"
+
+    row = [rel, pick.get("title", ""), rights, entry["imageSourceURL"],
+           pick["licence"], pick.get("page", "")]
+    if rel in by_path:
+        by_path[rel][:] = row
+    else:
+        body.append(row)
+        by_path[rel] = row
+    print(f"OK   {folder}: {rel} ({pick['licence']})")
+
+# keep every entry carrying the PhotoPath key so the schema stays uniform
+for e in index:
+    e.setdefault("PhotoPath", "")
+
+json.dump(index, open(REPO / "index.json", "w"), indent=2)
+open(REPO / "index.json", "a").write("\n")
+body.sort(key=lambda r: r[0])
+with open(REPO / "ATTRIBUTIONS.csv", "w", newline="") as f:
+    w = csv.writer(f)
+    w.writerow(header)
+    w.writerows(body)
+print("\nindex.json + ATTRIBUTIONS.csv updated — review `git diff`, commit on a branch.")

--- a/tools/commons_gather.py
+++ b/tools/commons_gather.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Gather openly-licensed image candidates from Wikimedia Commons (+ NASA Images).
+
+For every index.json entry whose imageStatus starts with "pending", search
+Commons for spacecraft imagery, keep only results that (a) carry a
+machine-readable open licence and (b) pass a name-token filter, and write
+them to tools/out/candidates.json for human review via make_gallery.py.
+
+Only sources with explicit machine-readable licences are automated —
+see ASSET-LICENSING.md. Never add a scraper for arbitrary websites here.
+
+Usage:
+    python3 tools/commons_gather.py                  # all pending entries
+    python3 tools/commons_gather.py alos-2 goes-16   # specific folders
+    python3 tools/commons_gather.py --terms "ESA logo" --key esa-logo
+"""
+
+import argparse
+import json
+import re
+import sys
+import time
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+OUT = REPO / "tools" / "out"
+
+COMMONS_API = "https://commons.wikimedia.org/w/api.php"
+NASA_API = "https://images-api.nasa.gov/search"
+UA = "satellite-visuals-curation/1.0 (https://github.com/gamedaygeorge/satellite-visuals)"
+
+# Licences we accept, matched against Commons extmetadata LicenseShortName.
+# The deny-list is checked first: NC/ND variants share the "CC BY" prefix,
+# so a prefix allowlist alone would let them through.
+DENIED_LICENCE = re.compile(
+    r"\b(nc|nd)\b|non[ -]?commercial|no[ -]?deriv|fair use|copyright",
+    re.IGNORECASE,
+)
+OPEN_LICENCE = re.compile(
+    r"^(public domain|pd\b|no restrictions|cc0|cc[ -]by(?:[ -]sa)?(?:[ -][0-9.]+)?(?:[ -]igo)?|attribution\b|ogl)",
+    re.IGNORECASE,
+)
+
+
+def licence_ok(licence: str) -> bool:
+    return bool(licence) and not DENIED_LICENCE.search(licence) and bool(OPEN_LICENCE.search(licence))
+
+
+def fetch_json(url: str) -> dict:
+    req = urllib.request.Request(url, headers={"User-Agent": UA})
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return json.load(r)
+
+
+def norm(s: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", s.lower())
+
+
+def commons_search(query: str, limit: int = 20) -> list:
+    params = urllib.parse.urlencode({
+        "action": "query", "format": "json", "list": "search",
+        "srsearch": query, "srnamespace": 6, "srlimit": limit,
+    })
+    data = fetch_json(f"{COMMONS_API}?{params}")
+    return [hit["title"] for hit in data.get("query", {}).get("search", [])]
+
+
+def commons_imageinfo(titles: list) -> list:
+    """Return per-file url/thumb/licence/author for openly-licensed files."""
+    results = []
+    for i in range(0, len(titles), 20):
+        params = urllib.parse.urlencode({
+            "action": "query", "format": "json",
+            "titles": "|".join(titles[i:i + 20]),
+            "prop": "imageinfo",
+            "iiprop": "url|extmetadata|size",
+            "iiurlwidth": 480,
+        })
+        data = fetch_json(f"{COMMONS_API}?{params}")
+        for page in data.get("query", {}).get("pages", {}).values():
+            for info in page.get("imageinfo", []):
+                meta = info.get("extmetadata", {})
+                licence = meta.get("LicenseShortName", {}).get("value", "")
+                if not licence_ok(licence):
+                    continue
+                artist = re.sub(r"<[^>]+>", "", meta.get("Artist", {}).get("value", "")).strip()
+                credit = re.sub(r"<[^>]+>", "", meta.get("Credit", {}).get("value", "")).strip()
+                results.append({
+                    "source": "commons",
+                    "title": page.get("title", ""),
+                    "url": info.get("url", ""),
+                    "thumb": info.get("thumburl", info.get("url", "")),
+                    "page": info.get("descriptionurl", ""),
+                    "licence": licence,
+                    "artist": artist,
+                    "credit": credit or artist,
+                    "width": info.get("width"),
+                    "height": info.get("height"),
+                })
+    return results
+
+
+def nasa_search(query: str, limit: int = 10) -> list:
+    params = urllib.parse.urlencode({"q": query, "media_type": "image", "page_size": limit})
+    try:
+        data = fetch_json(f"{NASA_API}?{params}")
+    except Exception:
+        return []
+    out = []
+    for item in data.get("collection", {}).get("items", [])[:limit]:
+        meta = (item.get("data") or [{}])[0]
+        links = item.get("links") or [{}]
+        out.append({
+            "source": "nasa-images",
+            "title": meta.get("title", ""),
+            "url": links[0].get("href", ""),
+            "thumb": links[0].get("href", ""),
+            "page": f"https://images.nasa.gov/details/{meta.get('nasa_id','')}",
+            "licence": "Public domain (NASA)",
+            "artist": meta.get("secondary_creator", "") or "NASA",
+            "credit": meta.get("secondary_creator", "") or "NASA",
+        })
+    return out
+
+
+def candidates_for(name: str, extra_terms: list) -> list:
+    tokens = [norm(name)]
+    queries = extra_terms or [
+        f"{name} satellite", f"{name} spacecraft", f"{name} artist impression",
+    ]
+    titles = []
+    for q in queries:
+        titles += commons_search(q)
+        time.sleep(0.3)
+    # de-dup, then require the mission token in the filename unless the
+    # caller supplied explicit terms (e.g. logo searches)
+    titles = list(dict.fromkeys(titles))
+    if not extra_terms:
+        titles = [t for t in titles if any(tok and tok in norm(t) for tok in tokens)]
+    found = commons_imageinfo(titles)
+    found += nasa_search(name if not extra_terms else extra_terms[0])
+    if not extra_terms:
+        found = [f for f in found if any(tok and tok in norm(f["title"]) for tok in tokens)]
+    return found
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("folders", nargs="*", help="folder names to gather for (default: all pending)")
+    ap.add_argument("--terms", help="explicit search terms (skips the mission-name queries + token filter)")
+    ap.add_argument("--key", help="output key to file --terms results under")
+    args = ap.parse_args()
+
+    OUT.mkdir(exist_ok=True)
+    out_path = OUT / "candidates.json"
+    results = json.load(open(out_path)) if out_path.exists() else {}
+
+    if args.terms:
+        key = args.key or norm(args.terms)
+        results[key] = {"query": args.terms, "candidates": candidates_for(args.terms, [args.terms])}
+        print(f"{key}: {len(results[key]['candidates'])} candidates")
+    else:
+        index = json.load(open(REPO / "index.json"))
+        for entry in index:
+            folder = entry["SVGColourPath"].split("/")[1]
+            if args.folders and folder not in args.folders:
+                continue
+            if not args.folders and not entry.get("imageStatus", "").startswith("pending"):
+                continue
+            name = entry.get("missionName") or folder
+            cands = candidates_for(name, [])
+            results[folder] = {
+                "missionID": entry.get("missionID", ""),
+                "missionName": name,
+                "candidates": cands,
+            }
+            print(f"{folder}: {len(cands)} candidates")
+
+    json.dump(results, open(out_path, "w"), indent=2)
+    print(f"\nWrote {out_path.relative_to(REPO)} — next: python3 tools/make_gallery.py")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/make_gallery.py
+++ b/tools/make_gallery.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Render tools/out/candidates.json as a clickable review gallery.
+
+Open tools/out/gallery.html in a browser, pick at most one image per
+mission (or "none of these"), then click "Export picks" to download
+picks.json. Apply it with tools/apply_picks.py.
+
+The gallery is a disposable artifact — tools/out/ is gitignored.
+"""
+
+import html
+import json
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+OUT = REPO / "tools" / "out"
+
+candidates = json.load(open(OUT / "candidates.json"))
+
+cards = []
+for key, block in sorted(candidates.items()):
+    options = []
+    for i, c in enumerate(block["candidates"]):
+        options.append(f"""
+        <label class="card">
+          <input type="radio" name="{html.escape(key)}" value="{i}">
+          <img src="{html.escape(c['thumb'])}" loading="lazy">
+          <div class="meta">
+            <div class="t">{html.escape(c['title'])}</div>
+            <div>{html.escape(c['licence'])} — {html.escape(c['credit'][:80])}</div>
+            <a href="{html.escape(c['page'])}" target="_blank">source page</a>
+          </div>
+        </label>""")
+    cards.append(f"""
+    <section data-key="{html.escape(key)}">
+      <h2>{html.escape(key)} <small>{html.escape(block.get('missionName', ''))}</small></h2>
+      <label class="card none"><input type="radio" name="{html.escape(key)}" value="none" checked> none of these</label>
+      {''.join(options)}
+    </section>""")
+
+# "</" -> "<\/" so external-API strings (titles/credits) cannot close the
+# script element; the escape is a no-op to the JSON parser.
+data_json = json.dumps(candidates).replace("</", "<\\/")
+
+page = f"""<!doctype html>
+<meta charset="utf-8">
+<title>satellite-visuals candidate review</title>
+<style>
+ body {{ font: 14px/1.4 system-ui; margin: 2rem; }}
+ section {{ border-top: 1px solid #ccc; padding: 1rem 0; }}
+ .card {{ display: inline-block; width: 240px; vertical-align: top; margin: 0 8px 8px 0;
+          border: 2px solid #ddd; border-radius: 6px; padding: 6px; cursor: pointer; }}
+ .card:has(input:checked) {{ border-color: #0a7; background: #f0fbf7; }}
+ .card img {{ max-width: 100%; max-height: 160px; display: block; margin: auto; }}
+ .card .t {{ font-weight: 600; overflow-wrap: anywhere; }}
+ .none {{ width: auto; }}
+ #export {{ position: fixed; top: 1rem; right: 1rem; padding: .6rem 1rem; }}
+</style>
+<button id="export">Export picks</button>
+{''.join(cards)}
+<script>
+const DATA = {data_json};
+document.getElementById('export').onclick = () => {{
+  const picks = {{}};
+  for (const section of document.querySelectorAll('section')) {{
+    const key = section.dataset.key;
+    const sel = section.querySelector('input:checked');
+    if (sel && sel.value !== 'none') picks[key] = DATA[key].candidates[Number(sel.value)];
+  }}
+  const blob = new Blob([JSON.stringify(picks, null, 2)], {{type: 'application/json'}});
+  const a = Object.assign(document.createElement('a'), {{
+    href: URL.createObjectURL(blob), download: 'picks.json'
+  }});
+  a.click();
+}};
+</script>
+"""
+
+path = OUT / "gallery.html"
+path.write_text(page)
+print(f"Wrote {path.relative_to(REPO)} — open it in a browser, pick, Export picks.")


### PR DESCRIPTION
Stacked on #103 (which is stacked on #102). Merge order: #102 → #103 → this; retarget each before deleting its base branch.

## The workflow: auto-gather → human-pick → apply

Rebuilds the pipeline proven in June (the scripts lived in /tmp and were lost) as permanent, documented tooling:

- **`tools/commons_gather.py`** — per pending `index.json` entry, searches Wikimedia Commons (File namespace) with mission-name queries + a name-token filter, keeps only files whose `LicenseShortName` matches the open-licence allowlist, and pulls URL/licence/credit machine-readably. NASA Images API as a public-domain secondary. `--terms "ESA logo" --key esa-logo` mode reuses it for the #101 logo searches. Only sources with explicit machine-readable licences are automated, per `ASSET-LICENSING.md`.
- **`tools/make_gallery.py`** — renders candidates as a clickable gallery; the reviewer picks at most one image per mission (most hits are the satellite's *data*, not the satellite — this step is irreducibly human) and exports `picks.json`.
- **`tools/apply_picks.py`** — downloads each pick to `satellites/<folder>/<folder>-photo.<ext>` and writes all the paperwork: `PhotoPath` (new, uniform field), `imageSourceURL`, `imageRightsHolder`, `imageLicense`, `imageCredit`, `imageStatus: licensed` in `index.json`, plus the `ATTRIBUTIONS.csv` row.
- `tools/out/` gitignored — candidates/galleries are disposable.

**Verified live:** alos-2 returned the CC BY-SA 4.0 PALSAR-2 render; goes-16 returned 15 public-domain candidates; the apply step was round-tripped on goes-16 and reverted.

## TASKING.md

Self-contained handover brief for the incoming curator: the golden rules (attribution ≠ licence, no web-search sourcing, Tier D never without permission, SVGs original not traced, logos never redrawn, branch+PR per batch), the five-step photo batch workflow, the manual worklist, #99 mission-ID blanks, the #101 agency-logos task with its trademark-editorial-use regime, the new-folder convention, and who decides what.

Related: #99, #101.